### PR TITLE
Card type detection fixed

### DIFF
--- a/SwiftLuhn/Classes/SwiftLuhn.swift
+++ b/SwiftLuhn/Classes/SwiftLuhn.swift
@@ -24,7 +24,7 @@ open class SwiftLuhn {
             var values: [CardType] = []
             var index = 1
             while let element = self.init(rawValue: index) {
-                values.append(element);
+                values.append(element)
                 index += 1
             }
             return values


### PR DESCRIPTION
Hi @maxkramer 

The PR fixes the issue #18

The caseIterable protocol works for enumerations without associated values, so I have added a simple solution to get the count of all enum cases:

Please review.